### PR TITLE
Add helmchart files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,43 @@ The Operator acts on the following [Custom Resource Definitions (CRDs)](https://
 
 ### Installation
 
+#### Option 1: Using Helm (Recommended)
+
+Add the Helm repository and install the chart:
+
+```sh
+helm install gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace
+```
+
+Or install with custom values:
+
+```sh
+helm install gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace \
+  --set image.tag=v0.1.0 \
+  --set resources.limits.memory=256Mi
+```
+
+To upgrade:
+
+```sh
+helm upgrade gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system
+```
+
+To uninstall:
+
+```sh
+helm uninstall gobackup-operator --namespace gobackup-operator-system
+```
+
+See [charts/gobackup-operator/README.md](charts/gobackup-operator/README.md) for all available configuration options.
+
+#### Option 2: Using Kustomize/Make
+
 1. Install Custom Resource Definitions (CRDs):
 
 ```sh
@@ -274,6 +311,8 @@ gobackup-operator/
 ├── .github/               # CI/CD workflows (GitHub Actions)
 ├── api/                   # API definitions (CustomResourceDefinitions)
 ├── build/                 # Build artifacts
+├── charts/                # Helm charts
+│   └── gobackup-operator/ # Main Helm chart for the operator
 ├── cmd/                   # Entry point for the operator
 ├── config/
 │   ├── crd/               # Custom Resource Definitions (CRDs)

--- a/charts/gobackup-operator/.helmignore
+++ b/charts/gobackup-operator/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+

--- a/charts/gobackup-operator/Chart.yaml
+++ b/charts/gobackup-operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gobackup-operator
+description: A Helm chart for GoBackup Operator - Kubernetes operator for managing database backups
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/gobackup/gobackup-operator
+sources:
+  - https://github.com/gobackup/gobackup-operator
+maintainers:
+  - name: gobackup
+    url: https://github.com/gobackup
+keywords:
+  - backup
+  - database
+  - operator
+  - kubernetes
+  - postgresql
+  - redis
+  - s3
+  - gcs
+  - azure
+kubeVersion: ">=1.19.0-0"
+

--- a/charts/gobackup-operator/README.md
+++ b/charts/gobackup-operator/README.md
@@ -1,0 +1,271 @@
+# GoBackup Operator Helm Chart
+
+A Helm chart for deploying the GoBackup Operator on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+
+## Installation
+
+### Add the repository (if published to a Helm repository)
+
+```bash
+helm repo add gobackup https://gobackup.github.io/gobackup-operator
+helm repo update
+```
+
+### Install the chart
+
+```bash
+helm install gobackup-operator gobackup/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace
+```
+
+Or install from local chart:
+
+```bash
+helm install gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace
+```
+
+### Upgrade
+
+```bash
+helm upgrade gobackup-operator gobackup/gobackup-operator \
+  --namespace gobackup-operator-system
+```
+
+### Uninstall
+
+```bash
+helm uninstall gobackup-operator --namespace gobackup-operator-system
+```
+
+> **Note:** By default, CRDs are kept when uninstalling the chart. To remove them:
+> ```bash
+> kubectl delete crd backups.gobackup.io databases.gobackup.io storages.gobackup.io
+> ```
+
+## Configuration
+
+The following table lists the configurable parameters of the GoBackup Operator chart and their default values.
+
+### General
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of operator replicas | `1` |
+| `nameOverride` | Override the chart name | `""` |
+| `fullnameOverride` | Override the full name | `""` |
+
+### Image
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Operator image repository | `ghcr.io/gobackup/gobackup-operator` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | Image tag (defaults to chart appVersion) | `""` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+
+### Service Account
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.annotations` | Service account annotations | `{}` |
+| `serviceAccount.name` | Service account name | `""` |
+
+### Security
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `podSecurityContext.runAsNonRoot` | Run as non-root user | `true` |
+| `securityContext.allowPrivilegeEscalation` | Allow privilege escalation | `false` |
+| `securityContext.capabilities.drop` | Drop capabilities | `["ALL"]` |
+
+### Resources
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `128Mi` |
+| `resources.requests.cpu` | CPU request | `10m` |
+| `resources.requests.memory` | Memory request | `64Mi` |
+
+### Leader Election
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `leaderElection.enabled` | Enable leader election | `true` |
+
+### Probes
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `livenessProbe.httpGet.path` | Liveness probe path | `/healthz` |
+| `livenessProbe.httpGet.port` | Liveness probe port | `8081` |
+| `livenessProbe.initialDelaySeconds` | Initial delay | `15` |
+| `livenessProbe.periodSeconds` | Period | `20` |
+| `readinessProbe.httpGet.path` | Readiness probe path | `/readyz` |
+| `readinessProbe.httpGet.port` | Readiness probe port | `8081` |
+| `readinessProbe.initialDelaySeconds` | Initial delay | `5` |
+| `readinessProbe.periodSeconds` | Period | `10` |
+
+### Scheduling
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Tolerations | `[]` |
+| `affinity` | Affinity rules | `{}` |
+| `podAnnotations` | Pod annotations | `{}` |
+
+### CRDs
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `crds.install` | Install CRDs | `true` |
+| `crds.keep` | Keep CRDs on uninstall | `true` |
+
+### Metrics & Monitoring
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `metrics.enabled` | Enable metrics endpoint | `false` |
+| `metrics.service.port` | Metrics service port | `8080` |
+| `metrics.service.annotations` | Metrics service annotations | `{}` |
+| `serviceMonitor.enabled` | Enable ServiceMonitor (requires Prometheus Operator) | `false` |
+| `serviceMonitor.interval` | Scrape interval | `30s` |
+| `serviceMonitor.scrapeTimeout` | Scrape timeout | `10s` |
+| `serviceMonitor.labels` | ServiceMonitor labels | `{}` |
+| `serviceMonitor.annotations` | ServiceMonitor annotations | `{}` |
+
+## Examples
+
+### Basic installation
+
+```bash
+helm install gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace
+```
+
+### With custom resources
+
+```bash
+helm install gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace \
+  --set resources.limits.memory=256Mi \
+  --set resources.requests.memory=128Mi
+```
+
+### With Prometheus monitoring
+
+```bash
+helm install gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace \
+  --set metrics.enabled=true \
+  --set serviceMonitor.enabled=true
+```
+
+### With custom image
+
+```bash
+helm install gobackup-operator ./charts/gobackup-operator \
+  --namespace gobackup-operator-system \
+  --create-namespace \
+  --set image.repository=my-registry/gobackup-operator \
+  --set image.tag=v1.0.0
+```
+
+## Getting Started After Installation
+
+After installing the chart, you can start creating backup resources:
+
+### 1. Create a Storage resource
+
+```yaml
+apiVersion: gobackup.io/v1
+kind: Storage
+metadata:
+  name: my-s3-storage
+spec:
+  type: s3
+  config:
+    bucket: my-backup-bucket
+    region: us-east-1
+    access_key_id_ref:
+      name: s3-credentials
+      key: access-key-id
+    secret_access_key_ref:
+      name: s3-credentials
+      key: secret-access-key
+```
+
+### 2. Create a Database resource
+
+```yaml
+apiVersion: gobackup.io/v1
+kind: Database
+metadata:
+  name: my-postgres
+spec:
+  type: postgresql
+  config:
+    host: postgres-service
+    port: 5432
+    database: mydb
+    username: postgres
+    password: mypassword
+```
+
+### 3. Create a Backup resource
+
+```yaml
+apiVersion: gobackup.io/v1
+kind: Backup
+metadata:
+  name: my-backup
+spec:
+  schedule:
+    cron: "0 2 * * *"  # Daily at 2 AM
+  databaseRefs:
+    - name: my-postgres
+      type: postgresql
+  storageRefs:
+    - name: my-s3-storage
+      type: s3
+      keep: 7
+```
+
+## Troubleshooting
+
+### Check operator logs
+
+```bash
+kubectl logs -n gobackup-operator-system -l app.kubernetes.io/name=gobackup-operator
+```
+
+### Check CRD status
+
+```bash
+kubectl get crd | grep gobackup
+```
+
+### Check backup status
+
+```bash
+kubectl get backups -A
+kubectl describe backup <backup-name>
+```
+
+## License
+
+MIT
+

--- a/charts/gobackup-operator/crds/gobackup.io_backups.yaml
+++ b/charts/gobackup-operator/crds/gobackup.io_backups.yaml
@@ -1,0 +1,294 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: backups.gobackup.io
+spec:
+  group: gobackup.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    shortNames:
+    - backup
+    singular: backup
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Backup is the Schema for the backups API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupSpec defines the desired state of Backup
+            properties:
+              afterScript:
+                description: AfterScript is the script to run after the backup
+                type: string
+              beforeScript:
+                description: BeforeScript is the script to run before the backup
+                type: string
+              compressWith:
+                description: CompressWith defines the compression to use
+                properties:
+                  type:
+                    type: string
+                type: object
+              databaseRefs:
+                description: DatabaseRefs represents the list of databases to backup
+                items:
+                  properties:
+                    apiGroup:
+                      type: string
+                    name:
+                      type: string
+                    type:
+                      description: Type is the database backend type (postgresql,
+                        redis, etc.) matching the Database resource's spec.type field
+                      type: string
+                  type: object
+                type: array
+              encodeWith:
+                description: EncodeWith defines the encoding to use
+                properties:
+                  type:
+                    type: string
+                type: object
+              persistence:
+                description: Persistence defines the storage for gobackup state (cycler.json)
+                properties:
+                  accessMode:
+                    description: 'AccessMode for the PVC (default: ReadWriteOnce)'
+                    type: string
+                  enabled:
+                    description: Enabled determines if a PVC should be created
+                    type: boolean
+                  size:
+                    description: 'Size of the PVC (default: 100Mi)'
+                    type: string
+                  storageClass:
+                    description: StorageClass to use for the PVC
+                    type: string
+                type: object
+              schedule:
+                description: Schedule defines when the backup should run
+                properties:
+                  cron:
+                    description: The cron expression defining the schedule
+                    type: string
+                  failedJobsHistoryLimit:
+                    description: The number of failed finished jobs to retain
+                    format: int32
+                    type: integer
+                  startingDeadlineSeconds:
+                    description: Optional deadline in seconds for starting the job
+                      if it misses scheduled time for any reason
+                    format: int64
+                    type: integer
+                  successfulJobsHistoryLimit:
+                    description: The number of successful finished jobs to retain
+                    format: int32
+                    type: integer
+                  suspend:
+                    description: This flag tells the controller to suspend subsequent
+                      executions
+                    type: boolean
+                type: object
+              storageRefs:
+                description: StorageRefs represents the list of storages to backup
+                  to
+                items:
+                  properties:
+                    apiGroup:
+                      type: string
+                    keep:
+                      type: integer
+                    name:
+                      type: string
+                    timeout:
+                      type: integer
+                    type:
+                      description: Type is the storage backend type (s3, gcs, azure,
+                        local, ftp, etc.) matching the Storage resource's spec.type
+                        field
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: BackupStatus defines the observed state of Backup
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the backup's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureCount:
+                description: FailureCount tracks consecutive failures for alerting
+                  purposes
+                format: int32
+                type: integer
+              lastBackupTime:
+                description: LastBackupTime is the timestamp of the last backup attempt
+                format: date-time
+                type: string
+              lastRun:
+                description: |-
+                  LastRun contains the status of the most recent backup run
+                  Only the last run is kept to avoid status size explosion
+                properties:
+                  completionTime:
+                    description: CompletionTime is when the backup job completed
+                    format: date-time
+                    type: string
+                  jobName:
+                    description: JobName is the name of the Job that ran this backup
+                    type: string
+                  logs:
+                    description: |-
+                      Logs contains the last N lines of gobackup output (truncated to avoid large status)
+                      Only captured on failure to help debugging. Max 4096 characters.
+                    type: string
+                  message:
+                    description: |-
+                      Message contains a human-readable message indicating details about the backup
+                      This is truncated to avoid status size issues (max 1024 characters)
+                    type: string
+                  phase:
+                    description: Phase is the current phase of the backup (Pending,
+                      Running, Succeeded, Failed)
+                    type: string
+                  startTime:
+                    description: StartTime is when the backup job started
+                    format: date-time
+                    type: string
+                type: object
+              lastSuccessfulBackupTime:
+                description: LastSuccessfulBackupTime is the timestamp of the last
+                  successful backup
+                format: date-time
+                type: string
+              phase:
+                description: Phase is the current phase of the backup (Idle, Running,
+                  Succeeded, Failed)
+                type: string
+              recentRuns:
+                description: |-
+                  RecentRuns contains the status of recent backup runs (limited to last N runs)
+                  This is a sliding window - oldest entries are removed when limit is exceeded
+                  Default limit: 5 runs to prevent status bloat
+                items:
+                  description: BackupRunStatus represents the status of a single backup
+                    run
+                  properties:
+                    completionTime:
+                      description: CompletionTime is when the backup job completed
+                      format: date-time
+                      type: string
+                    jobName:
+                      description: JobName is the name of the Job that ran this backup
+                      type: string
+                    logs:
+                      description: |-
+                        Logs contains the last N lines of gobackup output (truncated to avoid large status)
+                        Only captured on failure to help debugging. Max 4096 characters.
+                      type: string
+                    message:
+                      description: |-
+                        Message contains a human-readable message indicating details about the backup
+                        This is truncated to avoid status size issues (max 1024 characters)
+                      type: string
+                    phase:
+                      description: Phase is the current phase of the backup (Pending,
+                        Running, Succeeded, Failed)
+                      type: string
+                    startTime:
+                      description: StartTime is when the backup job started
+                      format: date-time
+                      type: string
+                  type: object
+                maxItems: 5
+                type: array
+              successCount:
+                description: SuccessCount tracks total successful backups
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+

--- a/charts/gobackup-operator/crds/gobackup.io_databases.yaml
+++ b/charts/gobackup-operator/crds/gobackup.io_databases.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: databases.gobackup.io
+spec:
+  group: gobackup.io
+  names:
+    kind: Database
+    listKind: DatabaseList
+    plural: databases
+    shortNames:
+    - db
+    singular: database
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Database is the Schema for the databases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatabaseSpec defines the desired state of Database
+            properties:
+              config:
+                description: Config contains the database configuration
+                properties:
+                  args:
+                    description: |-
+                      Args are additional arguments for pg_dump (PostgreSQL) or redis-cli utility (Redis)
+                      For Redis, e.g.: --tls --cacert redis_ca.pem
+                    type: string
+                  args_redis:
+                    description: 'ArgsRedis are additional options for redis-cli utility,
+                      for example: --tls --cacert redis_ca.pem'
+                    type: string
+                  copy:
+                    description: Copy is used for local Redis server, just copy Redis
+                      dump.db
+                    type: boolean
+                  database:
+                    description: Database is the database name (PostgreSQL)
+                    type: string
+                  exclude_tables:
+                    description: ExcludeTables is an array of tables to exclude from
+                      backup (PostgreSQL)
+                    items:
+                      type: string
+                    type: array
+                  host:
+                    description: |-
+                      Host is the database server hostname
+                      Default for PostgreSQL: localhost, for Redis: 127.0.0.1
+                    type: string
+                  invoke_save:
+                    description: 'InvokeSave invokes save before backup (Redis). Default:
+                      true'
+                    type: boolean
+                  mode:
+                    description: 'Mode is the Redis dump mode. Default: copy'
+                    enum:
+                    - copy
+                    - sync
+                    type: string
+                  password:
+                    description: |-
+                      Password is the password for the database or Redis server
+                      Default for Redis: ""
+                    type: string
+                  port:
+                    description: |-
+                      Port is the database server port
+                      Default for PostgreSQL: 5432, for Redis: 6379
+                    type: integer
+                  rdb_path:
+                    description: 'RdbPath is the path to dump.rdb for Redis. Default:
+                      /var/lib/redis/dump.rdb'
+                    type: string
+                  socket:
+                    description: |-
+                      Socket is the database server socket
+                      For PostgreSQL: e.g. /var/run/postgresql/.s.PGSQL.5432
+                      For Redis: e.g. /var/run/redis/redis.sock
+                    type: string
+                  sync:
+                    description: Sync is used for remote Redis server to export
+                    type: boolean
+                  tables:
+                    description: Tables is an array of tables to backup (PostgreSQL)
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: |-
+                      Username is the username for the database (PostgreSQL)
+                      Default: root
+                    type: string
+                type: object
+              type:
+                description: Type is the database backend type
+                enum:
+                - postgresql
+                - redis
+                type: string
+            required:
+            - config
+            - type
+            type: object
+          status:
+            description: DatabaseStatus defines the observed state of Database
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+

--- a/charts/gobackup-operator/crds/gobackup.io_storages.yaml
+++ b/charts/gobackup-operator/crds/gobackup.io_storages.yaml
@@ -1,0 +1,368 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: storages.gobackup.io
+spec:
+  group: gobackup.io
+  names:
+    kind: Storage
+    listKind: StorageList
+    plural: storages
+    shortNames:
+    - storage
+    singular: storage
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Storage is the Schema for the storages API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StorageSpec defines the desired state of Storage
+            properties:
+              config:
+                description: Config contains the storage configuration
+                properties:
+                  access_key_id:
+                    description: |-
+                      AccessKeyID is the access key ID. Use access_key_id_ref to reference a Secret instead
+                      Used by: s3, oss, r2, spaces, b2, cos, us3, kodo, bos, minio, obs, tos, upyun
+                    type: string
+                  access_key_id_ref:
+                    description: |-
+                      AccessKeyIDRef references a Secret containing the access key ID
+                      Used by: s3, oss, r2, spaces, b2, cos, us3, kodo, bos, minio, obs, tos, upyun
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  account:
+                    description: |-
+                      Account is the Azure Storage Account name (alias: bucket)
+                      Required for: azure
+                    type: string
+                  account_id:
+                    description: |-
+                      AccountID is the account identifier
+                      Required for: r2 (Cloudflare R2)
+                    type: string
+                  bucket:
+                    description: |-
+                      Bucket is the bucket/container name
+                      Required for: s3, oss, gcs, r2, spaces, b2, cos, us3, kodo, bos, minio, obs, tos, upyun
+                    type: string
+                  client_id:
+                    description: |-
+                      ClientID is the Azure Client ID (format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+                      Required for: azure
+                    type: string
+                  client_secret:
+                    description: |-
+                      ClientSecret is the Azure Client Secret. Use client_secret_ref to reference a Secret instead
+                      Required for: azure
+                    type: string
+                  client_secret_ref:
+                    description: |-
+                      ClientSecretRef references a Secret containing the Azure Client Secret
+                      Used by: azure
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  container:
+                    description: |-
+                      Container is the Azure container name
+                      Required for: azure
+                    type: string
+                  credentials:
+                    description: |-
+                      Credentials is the JSON content of Google Cloud Application Credentials. Use credentials_ref to reference a Secret instead
+                      Used by: gcs
+                    type: string
+                  credentials_file:
+                    description: |-
+                      CredentialsFile is the path to Google Cloud Application Credentials file
+                      Used by: gcs
+                    type: string
+                  credentials_ref:
+                    description: |-
+                      CredentialsRef references a Secret containing the Google Cloud Application Credentials JSON
+                      Used by: gcs
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  endpoint:
+                    description: |-
+                      Endpoint is the custom endpoint URL for S3-compatible services
+                      Used by: s3, oss, r2, spaces, b2, minio, and other S3-compatible services
+                    type: string
+                  force_path_style:
+                    description: |-
+                      ForcePathStyle forces path-style URLs instead of virtual-hosted-style
+                      Used by: s3 and S3-compatible services
+                    type: boolean
+                  host:
+                    description: |-
+                      Host is the server hostname
+                      Required for: ftp, sftp, scp
+                    type: string
+                  keep:
+                    description: |-
+                      Keep specifies how many backups to retain at this storage location
+                      Used by: all storage types
+                    type: integer
+                  max_retries:
+                    description: |-
+                      MaxRetries is the maximum number of retry attempts. Default: 3
+                      Used by: s3, oss, r2, spaces, b2, cos, us3, kodo, bos, minio, obs, tos, upyun
+                    type: integer
+                  passphrase:
+                    description: |-
+                      Passphrase is the password for the private key if present
+                      Used by: sftp, scp
+                    type: string
+                  passphrase_ref:
+                    description: |-
+                      PassphraseRef references a Secret containing the private key passphrase
+                      Used by: sftp, scp
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  password:
+                    description: |-
+                      Password for authentication. Use password_ref to reference a Secret instead
+                      Used by: ftp, sftp, scp, webdav
+                    type: string
+                  password_ref:
+                    description: |-
+                      PasswordRef references a Secret containing the password
+                      Used by: ftp, sftp, scp, webdav
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  path:
+                    description: |-
+                      Path is the remote path for saving backup files
+                      Used by: all storage types except azure (uses container)
+                    type: string
+                  port:
+                    description: |-
+                      Port is the server port. Default varies by protocol (ftp: 21, sftp: 22, scp: 22)
+                      Used by: ftp, sftp, scp
+                    type: integer
+                  private_key:
+                    description: |-
+                      PrivateKey is the path to SSH private key. Default: ~/.ssh/id_rsa
+                      Used by: sftp, scp
+                    type: string
+                  private_key_ref:
+                    description: |-
+                      PrivateKeyRef references a Secret containing the SSH private key content
+                      Used by: sftp, scp
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  region:
+                    description: |-
+                      Region is the storage region. Default varies by provider (s3: us-east-1, oss: cn-hangzhou, spaces: nyc1, b2: us-east-001, minio: us-east-1)
+                      Used by: s3, oss, spaces, b2, minio, and other S3-compatible services
+                    type: string
+                  root:
+                    description: |-
+                      Root is the WebDAV server root URL (e.g., http://localhost:8080)
+                      Required for: webdav
+                    type: string
+                  secret_access_key:
+                    description: |-
+                      SecretAccessKey is the secret access key. Use secret_access_key_ref to reference a Secret instead
+                      Used by: s3, oss, r2, spaces, b2, cos, us3, kodo, bos, minio, obs, tos, upyun
+                    type: string
+                  secret_access_key_ref:
+                    description: |-
+                      SecretAccessKeyRef references a Secret containing the secret access key
+                      Used by: s3, oss, r2, spaces, b2, cos, us3, kodo, bos, minio, obs, tos, upyun
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  storage_class:
+                    description: |-
+                      StorageClass is the storage class. Default varies by provider (s3: STANDARD_IA, oss: STANDARD_IA, spaces: STANDARD, b2: STANDARD)
+                      Used by: s3, oss, spaces, b2
+                    type: string
+                  tenant_id:
+                    description: |-
+                      TenantID is the Azure Tenant ID (format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+                      Required for: azure
+                    type: string
+                  timeout:
+                    description: |-
+                      Timeout is the upload timeout in seconds. Default: 300
+                      Used by: s3, oss, ftp, sftp, scp, gcs, azure, r2, spaces, b2, cos, us3, kodo, bos, minio, obs, tos, upyun
+                    type: integer
+                  username:
+                    description: |-
+                      Username for authentication
+                      Used by: ftp, sftp, scp, webdav
+                    type: string
+                type: object
+              type:
+                description: Type is the storage backend type
+                enum:
+                - local
+                - ftp
+                - sftp
+                - scp
+                - webdav
+                - s3
+                - oss
+                - gcs
+                - azure
+                - r2
+                - spaces
+                - b2
+                - cos
+                - us3
+                - kodo
+                - bos
+                - minio
+                - obs
+                - tos
+                - upyun
+                type: string
+            required:
+            - config
+            - type
+            type: object
+          status:
+            description: StorageStatus defines the observed state of Storage
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+

--- a/charts/gobackup-operator/templates/NOTES.txt
+++ b/charts/gobackup-operator/templates/NOTES.txt
@@ -1,0 +1,85 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+GoBackup Operator is now running in your cluster.
+
+## Getting Started
+
+1. Create a Storage resource to define where backups will be stored:
+
+   ```yaml
+   apiVersion: gobackup.io/v1
+   kind: Storage
+   metadata:
+     name: my-s3-storage
+   spec:
+     type: s3
+     config:
+       bucket: my-backup-bucket
+       region: us-east-1
+       access_key_id_ref:
+         name: s3-credentials
+         key: access-key-id
+       secret_access_key_ref:
+         name: s3-credentials
+         key: secret-access-key
+   ```
+
+2. Create a Database resource to define the database to backup:
+
+   ```yaml
+   apiVersion: gobackup.io/v1
+   kind: Database
+   metadata:
+     name: my-postgres
+   spec:
+     type: postgresql
+     config:
+       host: postgres-service
+       port: 5432
+       database: mydb
+       username: postgres
+       password: mypassword
+   ```
+
+3. Create a Backup resource to schedule backups:
+
+   ```yaml
+   apiVersion: gobackup.io/v1
+   kind: Backup
+   metadata:
+     name: my-backup
+   spec:
+     schedule:
+       cron: "0 2 * * *"  # Daily at 2 AM
+     databaseRefs:
+       - name: my-postgres
+         type: postgresql
+     storageRefs:
+       - name: my-s3-storage
+         type: s3
+         keep: 7
+   ```
+
+## Useful Commands
+
+- List all backups:
+  $ kubectl get backups
+
+- List all databases:
+  $ kubectl get databases
+
+- List all storages:
+  $ kubectl get storages
+
+- View backup status:
+  $ kubectl describe backup <backup-name>
+
+For more information, visit: https://github.com/gobackup/gobackup-operator
+

--- a/charts/gobackup-operator/templates/_helpers.tpl
+++ b/charts/gobackup-operator/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gobackup-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gobackup-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gobackup-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gobackup-operator.labels" -}}
+helm.sh/chart: {{ include "gobackup-operator.chart" . }}
+{{ include "gobackup-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service | default "Helm" }}
+app.kubernetes.io/part-of: gobackup-operator
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gobackup-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gobackup-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+control-plane: controller-manager
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gobackup-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gobackup-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the image name
+*/}}
+{{- define "gobackup-operator.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+

--- a/charts/gobackup-operator/templates/clusterrole.yaml
+++ b/charts/gobackup-operator/templates/clusterrole.yaml
@@ -1,0 +1,89 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "gobackup-operator.fullname" . }}-manager-role
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gobackup.io
+  resources:
+  - backups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gobackup.io
+  resources:
+  - backups/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gobackup.io
+  resources:
+  - backups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gobackup.io
+  resources:
+  - databases
+  - postgresqls
+  - s3s
+  - storages
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/charts/gobackup-operator/templates/clusterrolebinding.yaml
+++ b/charts/gobackup-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "gobackup-operator.fullname" . }}-manager-rolebinding
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "gobackup-operator.fullname" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gobackup-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+

--- a/charts/gobackup-operator/templates/deployment.yaml
+++ b/charts/gobackup-operator/templates/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gobackup-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gobackup-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "gobackup-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gobackup-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: manager
+        image: {{ include "gobackup-operator.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /manager
+        args:
+        {{- if .Values.leaderElection.enabled }}
+        - --leader-elect
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+      terminationGracePeriodSeconds: 10
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/charts/gobackup-operator/templates/metrics-service.yaml
+++ b/charts/gobackup-operator/templates/metrics-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gobackup-operator.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: metrics
+    port: {{ .Values.metrics.service.port }}
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    {{- include "gobackup-operator.selectorLabels" . | nindent 4 }}
+{{- end }}
+

--- a/charts/gobackup-operator/templates/role.yaml
+++ b/charts/gobackup-operator/templates/role.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.leaderElection.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gobackup-operator.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end }}
+

--- a/charts/gobackup-operator/templates/rolebinding.yaml
+++ b/charts/gobackup-operator/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.leaderElection.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gobackup-operator.fullname" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gobackup-operator.fullname" . }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gobackup-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/charts/gobackup-operator/templates/serviceaccount.yaml
+++ b/charts/gobackup-operator/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gobackup-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/charts/gobackup-operator/templates/servicemonitor.yaml
+++ b/charts/gobackup-operator/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "gobackup-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gobackup-operator.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "gobackup-operator.selectorLabels" . | nindent 6 }}
+{{- end }}
+

--- a/charts/gobackup-operator/values.yaml
+++ b/charts/gobackup-operator/values.yaml
@@ -1,0 +1,103 @@
+# Default values for gobackup-operator.
+
+# Number of replicas for the operator deployment
+replicaCount: 1
+
+image:
+  repository: ghcr.io/gobackup/gobackup-operator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  # fsGroup: 1000
+
+# Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - "ALL"
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# Resource limits and requests
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+# Leader election configuration
+leaderElection:
+  enabled: true
+
+# Probes configuration
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 15
+  periodSeconds: 20
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# Node selector for the operator pod
+nodeSelector: {}
+
+# Tolerations for the operator pod
+tolerations: []
+
+# Affinity rules for the operator pod
+affinity: {}
+
+# CRD installation
+crds:
+  # Specifies whether CRDs should be installed
+  install: true
+  # Keep CRDs when the chart is uninstalled
+  keep: true
+
+# Metrics configuration
+metrics:
+  # Enable metrics endpoint
+  enabled: false
+  # Service configuration for metrics
+  service:
+    port: 8080
+    annotations: {}
+
+# ServiceMonitor configuration (requires Prometheus Operator)
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+  annotations: {}
+


### PR DESCRIPTION
## Description
Add helm chart to ease the operator installation.

## Changes
- Add a directory named charts/gobackup-operator including required helm installation

## Related Issues
#17 

## Checklist

- [X] Your go code is [formatted](https://go.dev/blog/gofmt). Your IDE should do it automatically for you.
- [X] New configuration options are reflected in CRD validation, [helm charts](https://github.com/gobackup/gobackup-operator/tree/main/charts) and [sample manifests](https://github.com/gobackup/gobackup-operator/tree/main/config/samples).
- [X] New functionality is covered by unit and/or e2e tests.
- [X] You have checked existing [open PRs](https://github.com/gobackup/gobackup-operator/pulls) for possible overlay and referenced them.