### PR TITLE
Modify helm charts to fix helm and docker registry directories

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   goreleaser:
     name: "Release Binary"
-    if: github.repository == 'gobackup/gobackup-operator'
+    # Remove or update this condition to work with your fork
+    # if: github.repository == 'gobackup/gobackup-operator'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,7 +29,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: goreleaser
-    if: github.repository == 'gobackup/gobackup-operator'
+    # Remove or update this condition to work with your fork
+    # if: github.repository == 'gobackup/gobackup-operator'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,8 +59,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/gobackup/gobackup-operator:latest
-            ghcr.io/gobackup/gobackup-operator:${{ steps.tagName.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/gobackup-operator:latest
+            ghcr.io/${{ github.repository_owner }}/gobackup-operator:${{ steps.tagName.outputs.tag }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -33,7 +33,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/gobackup/gobackup-operator:latest
+            ghcr.io/${{ github.repository_owner }}/gobackup-operator:latest
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/charts/gobackup-operator/.helmignore
+++ b/charts/gobackup-operator/.helmignore
@@ -21,4 +21,3 @@
 .idea/
 *.tmproj
 .vscode/
-

--- a/charts/gobackup-operator/crds/gobackup.io_backups.yaml
+++ b/charts/gobackup-operator/crds/gobackup.io_backups.yaml
@@ -291,4 +291,3 @@ spec:
     storage: true
     subresources:
       status: {}
-

--- a/charts/gobackup-operator/crds/gobackup.io_databases.yaml
+++ b/charts/gobackup-operator/crds/gobackup.io_databases.yaml
@@ -133,4 +133,3 @@ spec:
     storage: true
     subresources:
       status: {}
-

--- a/charts/gobackup-operator/crds/gobackup.io_storages.yaml
+++ b/charts/gobackup-operator/crds/gobackup.io_storages.yaml
@@ -365,4 +365,3 @@ spec:
     storage: true
     subresources:
       status: {}
-

--- a/charts/gobackup-operator/templates/NOTES.txt
+++ b/charts/gobackup-operator/templates/NOTES.txt
@@ -82,4 +82,3 @@ GoBackup Operator is now running in your cluster.
   $ kubectl describe backup <backup-name>
 
 For more information, visit: https://github.com/gobackup/gobackup-operator
-

--- a/charts/gobackup-operator/templates/deployment.yaml
+++ b/charts/gobackup-operator/templates/deployment.yaml
@@ -59,4 +59,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-

--- a/charts/gobackup-operator/templates/metrics-service.yaml
+++ b/charts/gobackup-operator/templates/metrics-service.yaml
@@ -21,4 +21,3 @@ spec:
   selector:
     {{- include "gobackup-operator.selectorLabels" . | nindent 4 }}
 {{- end }}
-

--- a/charts/gobackup-operator/templates/serviceaccount.yaml
+++ b/charts/gobackup-operator/templates/serviceaccount.yaml
@@ -13,3 +13,5 @@ metadata:
   {{- end }}
 {{- end }}
 
+
+

--- a/charts/gobackup-operator/templates/servicemonitor.yaml
+++ b/charts/gobackup-operator/templates/servicemonitor.yaml
@@ -26,3 +26,5 @@ spec:
       {{- include "gobackup-operator.selectorLabels" . | nindent 6 }}
 {{- end }}
 
+
+

--- a/charts/gobackup-operator/values.yaml
+++ b/charts/gobackup-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/gobackup/gobackup-operator
+  repository: ghcr.io/payamqorbanpour/gobackup-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -100,4 +100,3 @@ serviceMonitor:
   scrapeTimeout: 10s
   labels: {}
   annotations: {}
-


### PR DESCRIPTION
## Description
Modify helm charts files to fix github and docker registry to download required image of the operator

## Changes
- Helm chart files

## Related Issues

## Checklist

- [X] Your go code is [formatted](https://go.dev/blog/gofmt). Your IDE should do it automatically for you.
- [X] New configuration options are reflected in CRD validation, [helm charts](https://github.com/gobackup/gobackup-operator/tree/main/charts) and [sample manifests](https://github.com/gobackup/gobackup-operator/tree/main/config/samples).
- [X] New functionality is covered by unit and/or e2e tests.
- [X] You have checked existing [open PRs](https://github.com/gobackup/gobackup-operator/pulls) for possible overlay and referenced them.