### PR TITLE
Fix/fix secret ownership

### DIFF
--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -315,6 +315,41 @@ func (in *DatabaseConfig) DeepCopyInto(out *DatabaseConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AuthDB != nil {
+		in, out := &in.AuthDB, &out.AuthDB
+		*out = new(string)
+		**out = **in
+	}
+	if in.Oplog != nil {
+		in, out := &in.Oplog, &out.Oplog
+		*out = new(bool)
+		**out = **in
+	}
+	if in.TrustServerCertificate != nil {
+		in, out := &in.TrustServerCertificate, &out.TrustServerCertificate
+		*out = new(bool)
+		**out = **in
+	}
+	if in.Token != nil {
+		in, out := &in.Token, &out.Token
+		*out = new(string)
+		**out = **in
+	}
+	if in.Bucket != nil {
+		in, out := &in.Bucket, &out.Bucket
+		*out = new(string)
+		**out = **in
+	}
+	if in.Organization != nil {
+		in, out := &in.Organization, &out.Organization
+		*out = new(string)
+		**out = **in
+	}
+	if in.Endpoints != nil {
+		in, out := &in.Endpoints, &out.Endpoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Mode != nil {
 		in, out := &in.Mode, &out.Mode
 		*out = new(string)


### PR DESCRIPTION
## Description
Modify reconcile to update backup status on each cycle and add owner reference to backup secret

## Changes
- Add update status to backup while reconcile
- Add owner reference to backup secret

## Related Issues

## Checklist

- [X] Your go code is [formatted](https://go.dev/blog/gofmt). Your IDE should do it automatically for you.
- [ ] New configuration options are reflected in CRD validation, [helm charts](https://github.com/gobackup/gobackup-operator/tree/main/charts) and [sample manifests](https://github.com/gobackup/gobackup-operator/tree/main/config/samples).
- [X] New functionality is covered by unit and/or e2e tests.
- [ ] You have checked existing [open PRs](https://github.com/gobackup/gobackup-operator/pulls) for possible overlay and referenced them.