### PR TITLE
ci: publish chart to gh-pages Helm repo index on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,31 @@ jobs:
               --target "${{ github.sha }}"
           fi
 
+      - name: Update gh-pages Helm repo index
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.chart.outputs.version }}"
+          TAG="v${VERSION}"
+          CHART_FILE="${{ env.CHART_NAME }}-${VERSION}.tgz"
+          URL_BASE="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+
+          git fetch origin gh-pages
+          git worktree add /tmp/ghpages FETCH_HEAD
+
+          STAGE="$(mktemp -d)"
+          cp ".cr-release-packages/${CHART_FILE}" "${STAGE}/"
+          # --merge keeps existing entries; each version's url points at its own release asset
+          helm repo index "${STAGE}" --url "${URL_BASE}" --merge /tmp/ghpages/index.yaml
+          cp "${STAGE}/index.yaml" /tmp/ghpages/index.yaml
+
+          cd /tmp/ghpages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.yaml
+          git commit -m "Update Helm repo index for ${VERSION}" || { echo "No index changes"; exit 0; }
+          git push origin HEAD:gh-pages
+
       - name: Install hint
         run: |
           echo "helm install my-release oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.CHART_NAME }} --version ${{ steps.chart.outputs.version }}"


### PR DESCRIPTION
The release job published to GHCR OCI + a GitHub Release asset but never updated the gh-pages index.yaml, which ArgoCD pulls from. New versions were therefore invisible to ArgoCD. Add a step that merges each released chart into the gh-pages index, pointing at its GitHub Release .tgz.

## Description


## Changes
- 

## Related Issues

## Checklist

- [ ] Your go code is [formatted](https://go.dev/blog/gofmt). Your IDE should do it automatically for you.
- [ ] New configuration options are reflected in CRD validation, [helm charts](https://github.com/gobackup/gobackup-operator/tree/main/charts) and [sample manifests](https://github.com/gobackup/gobackup-operator/tree/main/config/samples).
- [ ] New functionality is covered by unit and/or e2e tests.
- [ ] You have checked existing [open PRs](https://github.com/gobackup/gobackup-operator/pulls) for possible overlay and referenced them.